### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Michal Canecky
 maintainer=Michal Canecky
 sentence=Arduino Sleep is a small library that will add a sleep functionality to your project.
 paragraph=Arduino Sleep is a small library that will add a sleep functionality to your project. You can use it instead of default delay() function to save power. It works on ATMega328, ATTiny84 and ATTiny85. Just replace delay() with sdelay() that's it.
+category=Other
 url=https://github.com/cano64/ArduinoSleep
 architectures=avr


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library SleepDelay is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6. If you disagree with my category choice I'm happy to change the category to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.
