### PR TITLE
Remove sdelay.cpp

### DIFF
--- a/sdelay.cpp
+++ b/sdelay.cpp
@@ -1,1 +1,0 @@
-#include "sdelay.h";


### PR DESCRIPTION
This file is completely pointless and causes compilation to fail with
multiple definition errors. Arduino libraries are not required to
contain a .cpp file and in fact the official Arduino AVR Boards core's
EEPROM library consists of only a header file.