### PR TITLE
Uncomment the ISR

### DIFF
--- a/src/sdelay.cpp
+++ b/src/sdelay.cpp
@@ -10,10 +10,8 @@
 #include "sdelay.h"
 
 
-/*
 ISR(WDT_vect) { 
 }
-*/
 
 
 void sleepWithWDT(uint8_t wdt_period) {


### PR DESCRIPTION
An empty ISR is required because the default interrupt vector is the
reset vector. This causes the Arduino to reset whenever it comes out of
sleep.

This should fix https://github.com/cano64/ArduinoSleep/issues/8